### PR TITLE
CUSIP identifier not validated correctly

### DIFF
--- a/src/main/java/com/apptasticsoftware/lei/CusipValidator.java
+++ b/src/main/java/com/apptasticsoftware/lei/CusipValidator.java
@@ -38,7 +38,7 @@ public final class CusipValidator {
     static int calculateCheckDigit(String cusip) {
         int sum = 0;
 
-        for (int p = 1; p < cusip.length(); ++p) {
+        for (int p = 1; p <= cusip.length(); ++p) {
             int value = 0;
             int c = cusip.codePointAt(p-1);
             if (Character.isDigit(c)) {

--- a/src/test/java/com/apptasticsoftware/lei/CusipValidatorTest.java
+++ b/src/test/java/com/apptasticsoftware/lei/CusipValidatorTest.java
@@ -14,6 +14,7 @@ class CusipValidatorTest {
         assertTrue(CusipValidator.isValid("38259P508"));
         assertTrue(CusipValidator.isValid("594918104"));
         assertTrue(CusipValidator.isValid("68389X105"));
+        assertTrue(CusipValidator.isValid("912828H45"));
 
         // Dummy CUSIP
         assertTrue(CusipValidator.isValid("0*7833107"));


### PR DESCRIPTION
`912828H45` is not detected as a valid CUSIP identifier.

Example:
```java
boolean isValid =CusipValidator.isValid("912828H45")
```